### PR TITLE
feat(datasource): 引入 spring-retry 为数据源添加重试机制

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,22 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>2.7.0</version>

--- a/src/main/java/com/cong/fishisland/config/RetryConfig.java
+++ b/src/main/java/com/cong/fishisland/config/RetryConfig.java
@@ -1,0 +1,29 @@
+package com.cong.fishisland.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+@Configuration
+public class RetryConfig {
+
+    @Bean
+    public RetryTemplate retryTemplate() {
+        RetryTemplate retryTemplate = new RetryTemplate();
+
+        // 重试策略：最多3次
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
+        retryPolicy.setMaxAttempts(3);
+        retryTemplate.setRetryPolicy(retryPolicy);
+
+        // 退避策略：固定1秒间隔
+        FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
+        backOffPolicy.setBackOffPeriod(1000);
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+
+        return retryTemplate;
+    }
+
+}

--- a/src/main/java/com/cong/fishisland/datasource/hostpost/HuPuStreetDataSource.java
+++ b/src/main/java/com/cong/fishisland/datasource/hostpost/HuPuStreetDataSource.java
@@ -1,15 +1,20 @@
 package com.cong.fishisland.datasource.hostpost;
 
 import com.alibaba.fastjson.JSON;
+import com.cong.fishisland.common.ErrorCode;
+import com.cong.fishisland.common.exception.BusinessException;
 import com.cong.fishisland.model.entity.hot.HotPost;
 import com.cong.fishisland.model.enums.CategoryTypeEnum;
 import com.cong.fishisland.model.enums.UpdateIntervalEnum;
 import com.cong.fishisland.model.vo.hot.HotPostDataVO;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -24,15 +29,22 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class HuPuStreetDataSource implements DataSource {
 
     private static final String HUPU_URL = "https://bbs.hupu.com";
     private static final String USER_AGENT = "Mozilla/5.0(Windows NT 10.0;Win64;x64;rv:66.0)Gecko/20100101 Firefox/66.0";
-    String hupuStreetURL = "https://bbs.hupu.com/all-gambia";
+    String huPPuStreetURL = "https://bbs.hupu.com/all-gambia";
+
+    private final RetryTemplate retryTemplate;
 
     @Override
     public HotPost getHotPost() {
-        Document document = fetchDocument(hupuStreetURL);
+        return retryTemplate.execute(this::fetchHotPost);
+    }
+
+    public HotPost fetchHotPost(RetryContext context) {
+        Document document = fetchDocument(huPPuStreetURL);
 
         if (document == null) {
             log.error("无法获取虎扑步行街网页内容");
@@ -47,8 +59,12 @@ public class HuPuStreetDataSource implements DataSource {
             if (dataVO != null) {
                 dataList.add(dataVO);
             }
+            // 如果数据为空，则抛出异常进行重试
+            if (dataList.isEmpty()) {
+                log.warn("获取数据为空，尝试重试... 剩余次数：{}", context.getRetryCount());
+                throw new BusinessException(ErrorCode.NOT_FOUND_ERROR, "获取数据为空");
+            }
         }
-
         return HotPost.builder()
                 .sort(CategoryTypeEnum.GENERAL_DISCUSSION.getValue())
                 .name("虎扑步行街热榜")
@@ -89,7 +105,7 @@ public class HuPuStreetDataSource implements DataSource {
         try {
             String postUrl = listItem.select("a").attr("href");
             // 只有当 postUrl 为相对路径且有效时，才进行拼接并处理
-            if (postUrl.trim().isEmpty() || postUrl.equals(hupuStreetURL)) {
+            if (postUrl.trim().isEmpty() || postUrl.equals(huPPuStreetURL)) {
                 return null;
             }
             // 拼接完整的帖子 URL

--- a/src/main/java/com/cong/fishisland/job/cycle/IncSyncHostPostToMySQL.java
+++ b/src/main/java/com/cong/fishisland/job/cycle/IncSyncHostPostToMySQL.java
@@ -1,6 +1,8 @@
 package com.cong.fishisland.job.cycle;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.cong.fishisland.common.ErrorCode;
+import com.cong.fishisland.common.exception.BusinessException;
 import com.cong.fishisland.manager.DataSourceRegistry;
 
 import com.cong.fishisland.model.entity.hot.HotPost;
@@ -8,6 +10,7 @@ import com.cong.fishisland.model.enums.HotDataKeyEnum;
 import com.cong.fishisland.service.HotPostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
@@ -26,6 +29,7 @@ public class IncSyncHostPostToMySQL {
 
     private final DataSourceRegistry dataSourceRegistry;
     private final HotPostService hotPostService;
+    private final RetryTemplate retryTemplate;
 
     /**
      * 每半小时执行一次
@@ -36,31 +40,41 @@ public class IncSyncHostPostToMySQL {
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
         HotDataKeyEnum.getValues().forEach(key -> {
-            LambdaQueryWrapper<HotPost> hotPostLambdaQueryWrapper = new LambdaQueryWrapper<>();
-            hotPostLambdaQueryWrapper.eq(HotPost::getType, key);
-            HotPost oldHotPost = hotPostService.getOne(hotPostLambdaQueryWrapper);
-            if (oldHotPost != null) {
-                //如果更新时间间隔未到直接跳过
-                //小时制
-                BigDecimal updateInterval = oldHotPost.getUpdateInterval();
-                //转成时间戳
-                long updateIntervalMillis = updateInterval.multiply(new BigDecimal(60 * 60 * 1000)).longValue();
-                if (oldHotPost.getUpdateTime().getTime() + updateIntervalMillis > System.currentTimeMillis()) {
-                    log.info("加载===========>【{}】热榜数据跳过", HotDataKeyEnum.getEnumByValue(key).getText());
-                    return;
-                }
+            try {
+                retryTemplate.execute(context -> {
+                    updateHotPost(key);
+                    return null;
+                });
+            } catch (Exception e) {
+                log.error("更新热榜数据失败，已达到最大重试次数，放弃更新【{}】", key, e);
             }
-            HotPost hotPost = dataSourceRegistry.getDataSourceByType(key).getHotPost();
-            hotPost.setType(key);
-            if (oldHotPost != null) {
-                hotPost.setId(oldHotPost.getId());
-            }
-            hotPost.setUpdateTime(new Date());
-            hotPostService.saveOrUpdate(hotPost);
-            log.info("加载===========>【{}】热榜数据完成", hotPost.getTypeName());
         });
         stopWatch.stop();
-        long totalTimeMillis = stopWatch.getTotalTimeMillis();
-        log.info("更新热榜数据完成，耗时：{}ms", totalTimeMillis);
+        log.info("更新热榜数据完成，耗时：{}ms", stopWatch.getTotalTimeMillis());
+    }
+
+    private void updateHotPost(String key) {
+        LambdaQueryWrapper<HotPost> hotPostLambdaQueryWrapper = new LambdaQueryWrapper<>();
+        hotPostLambdaQueryWrapper.eq(HotPost::getType, key);
+        HotPost oldHotPost = hotPostService.getOne(hotPostLambdaQueryWrapper);
+        if (oldHotPost != null) {
+            //如果更新时间间隔未到直接跳过
+            //小时制
+            BigDecimal updateInterval = oldHotPost.getUpdateInterval();
+            //转成时间戳
+            long updateIntervalMillis = updateInterval.multiply(new BigDecimal(60 * 60 * 1000)).longValue();
+            if (oldHotPost.getUpdateTime().getTime() + updateIntervalMillis > System.currentTimeMillis()) {
+                log.info("加载===========>【{}】热榜数据跳过", HotDataKeyEnum.getEnumByValue(key).getText());
+                return;
+            }
+        }
+        HotPost hotPost = dataSourceRegistry.getDataSourceByType(key).getHotPost();
+        hotPost.setType(key);
+        if (oldHotPost != null) {
+            hotPost.setId(oldHotPost.getId());
+        }
+        hotPost.setUpdateTime(new Date());
+        hotPostService.saveOrUpdate(hotPost);
+        log.info("加载===========>【{}】热榜数据完成", hotPost.getTypeName());
     }
 }

--- a/src/test/java/com/cong/fishisland/utils/RetryTest.java
+++ b/src/test/java/com/cong/fishisland/utils/RetryTest.java
@@ -1,0 +1,108 @@
+package com.cong.fishisland.utils;
+
+import com.cong.fishisland.common.exception.BusinessException;
+import com.cong.fishisland.datasource.hostpost.ZhiBo8DataSource;
+import com.cong.fishisland.model.entity.hot.HotPost;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.retry.support.RetryTemplate;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RetryTest {
+
+    @Mock
+    private RetryTemplate retryTemplate;
+
+    @InjectMocks
+    private ZhiBo8DataSource zhiBo8DataSource;
+
+    private MockedStatic<Jsoup> mockedJsoup;
+
+    @BeforeEach
+    void setUp() {
+        retryTemplate = new RetryTemplate();
+        zhiBo8DataSource = new ZhiBo8DataSource(retryTemplate);
+
+        // 统一在 @BeforeEach 里 Mock Jsoup
+        mockedJsoup = Mockito.mockStatic(Jsoup.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 确保每次测试后释放静态 Mock，防止污染下一个测试
+        if (mockedJsoup != null) {
+            mockedJsoup.close();
+        }
+    }
+
+    @Test
+    void testFetchHotPost_WithRetries() throws Exception {
+        // 模拟 Jsoup 连接和 Document
+        Connection mockConnection = mock(Connection.class);
+        Document mockDocument = mock(Document.class);
+
+        // 让 Jsoup.connect() 返回 mockConnection
+        mockedJsoup.when(() -> Jsoup.connect(anyString())).thenReturn(mockConnection);
+        when(mockConnection.userAgent(anyString())).thenReturn(mockConnection);
+        when(mockConnection.timeout(anyInt())).thenReturn(mockConnection);
+
+        // 第一次和第二次调用 get() 抛出 IOException，第三次返回正常数据
+        when(mockConnection.get())
+                .thenThrow(new IOException("网络异常-1"))
+                .thenThrow(new IOException("网络异常-2"))
+                .thenReturn(mockDocument);
+
+        // Mock 解析逻辑，返回空数据列表
+        when(mockDocument.select(anyString())).thenReturn(new org.jsoup.select.Elements());
+
+        // 执行测试
+        HotPost hotPost = zhiBo8DataSource.getHotPost();
+
+        // 断言：重试后应该成功获取数据
+        assertNotNull(hotPost);
+        assertEquals("直播吧体育热榜", hotPost.getName());
+
+        // 验证 Jsoup.connect() 调用了三次
+        verify(mockConnection, times(3)).get();
+    }
+
+    @Test
+    void testFetchHotPost_AllRetriesFail() throws Exception {
+        // 模拟 Jsoup 连接
+        Connection mockConnection = mock(Connection.class);
+        mockedJsoup.when(() -> Jsoup.connect(anyString())).thenReturn(mockConnection);
+        when(mockConnection.userAgent(anyString())).thenReturn(mockConnection);
+        when(mockConnection.timeout(anyInt())).thenReturn(mockConnection);
+
+        // 模拟 Jsoup 失败三次
+        when(mockConnection.get()).thenThrow(new IOException("网络异常-1"))
+                .thenThrow(new IOException("网络异常-2"))
+                .thenThrow(new IOException("网络异常-3"));
+
+        // 执行测试，并断言抛出 BusinessException
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            zhiBo8DataSource.getHotPost();
+        });
+
+        assertEquals("获取数据失败", exception.getMessage());
+
+        // 确保 Jsoup.connect().get() 调用了三次
+        verify(mockConnection, times(3)).get();
+    }
+}
+


### PR DESCRIPTION
feat(datasource): 为数据源引入 spring-retry 添加重试机制

- 在 HuPuStreetDataSource 和 ZhiBo8DataSource 中集成 RetryTemplate
- 新增 RetryConfig 配置类，定义重试策略
- 修改 IncSyncHostPostToMySQL 任务，使用重试模板执行更新操作
- 增加单元测试验证重试机制

针对偶发出现的虎扑步行街和直播吧出现数据丢失情况引入重试机制