### PR TITLE
feat(hero): 添加英雄猜测功能- 在 HeroController 中添加记录猜对英雄次数和获取猜对英雄次数的接口

### DIFF
--- a/src/main/java/com/cong/fishisland/constant/RedisKey.java
+++ b/src/main/java/com/cong/fishisland/constant/RedisKey.java
@@ -31,6 +31,11 @@ public interface RedisKey {
 
     String HOT_POST_CACHE_KEY = "hot_post_list";
 
+    /**
+     * 记录猜对英雄次数
+     */
+    String GUESS_HERO_SUCCESS_COUNT = "guess:hero:success:count";
+
     static String getKey(String key, Object... objects) {
         return BASE_KEY + String.format(key, objects);
     }


### PR DESCRIPTION
- 在 RedisKey 中添加 GUESS_HERO_SUCCESS_COUNT 常量用于存储猜测成功次数