### PR TITLE
feat(post): 添加帖子加精功能并调整标签图标长度

### DIFF
--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -78,7 +78,7 @@ create table if not exists tags
     id         bigint auto_increment comment '标签id' primary key,
     tagsName   varchar(256)                       null comment '标签名',
     type       tinyint  default 0                 null comment '类型（0 官方创建，1 用户自定义）',
-    icon       varchar(20)                        null comment '图标',
+    icon       varchar(256)                       null comment '图标',
     color      varchar(20)                        null comment '颜色',
     sort       int      default 0                 not null comment '排序',
     createTime datetime default CURRENT_TIMESTAMP not null comment '创建时间',

--- a/src/main/java/com/cong/fishisland/controller/post/PostController.java
+++ b/src/main/java/com/cong/fishisland/controller/post/PostController.java
@@ -10,10 +10,7 @@ import com.cong.fishisland.common.ResultUtils;
 import com.cong.fishisland.constant.UserConstant;
 import com.cong.fishisland.common.exception.BusinessException;
 import com.cong.fishisland.common.exception.ThrowUtils;
-import com.cong.fishisland.model.dto.post.PostAddRequest;
-import com.cong.fishisland.model.dto.post.PostEditRequest;
-import com.cong.fishisland.model.dto.post.PostQueryRequest;
-import com.cong.fishisland.model.dto.post.PostUpdateRequest;
+import com.cong.fishisland.model.dto.post.*;
 import com.cong.fishisland.model.entity.post.Post;
 import com.cong.fishisland.model.entity.user.User;
 import com.cong.fishisland.model.vo.post.PostVO;
@@ -246,4 +243,16 @@ public class PostController {
         return ResultUtils.success(result);
     }
 
+    /**
+     * 设置帖子加精状态（仅管理员）
+     *
+     * @param request 帖子加精请求
+     * @return {@link BaseResponse}<{@link Boolean}>
+     */
+    @PostMapping("/featured")
+    @SaCheckRole(UserConstant.ADMIN_ROLE)
+    @ApiOperation(value = "设置帖子加精状态（仅管理员）")
+    public BaseResponse<Boolean> setFeaturedStatus(@RequestBody PostFeaturedRequest request) {
+        return ResultUtils.success(postService.setFeaturedStatus(request));
+    }
 }

--- a/src/main/java/com/cong/fishisland/model/dto/post/PostFeaturedRequest.java
+++ b/src/main/java/com/cong/fishisland/model/dto/post/PostFeaturedRequest.java
@@ -1,0 +1,25 @@
+package com.cong.fishisland.model.dto.post;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+/**
+ * 帖子加精请求
+ * @author 许林涛
+ * @date 2025年07月08日 9:03
+ */
+@Data
+public class PostFeaturedRequest implements Serializable {
+
+    /**
+     * id
+     */
+    private Long id;
+
+    /**
+     * 是否加精
+     */
+    private Integer isFeatured;
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/cong/fishisland/service/PostService.java
+++ b/src/main/java/com/cong/fishisland/service/PostService.java
@@ -3,6 +3,7 @@ package com.cong.fishisland.service;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.IService;
+import com.cong.fishisland.model.dto.post.PostFeaturedRequest;
 import com.cong.fishisland.model.dto.post.PostQueryRequest;
 import com.cong.fishisland.model.entity.post.Post;
 import com.cong.fishisland.model.vo.post.PostVO;
@@ -59,4 +60,11 @@ public interface PostService extends IService<Post> {
      * @param postId 帖子id
      */
     void incrementViewCountAsync(Long postId);
+
+    /**
+     * 设置帖子加精状态
+     * @param request 请求
+     * @return 布尔值
+     */
+    Boolean setFeaturedStatus(PostFeaturedRequest request);
 }

--- a/src/main/java/com/cong/fishisland/service/impl/tags/TagsServiceImpl.java
+++ b/src/main/java/com/cong/fishisland/service/impl/tags/TagsServiceImpl.java
@@ -43,7 +43,7 @@ public class TagsServiceImpl extends ServiceImpl<TagsMapper, Tags> implements Ta
         String icon = tags.getIcon();
         String color = tags.getColor();
         Integer sort = tags.getSort();
-        ThrowUtils.throwIf(StringUtils.isNotBlank(icon) && icon.length() > 20, ErrorCode.PARAMS_ERROR, "图标值过长");
+        ThrowUtils.throwIf(StringUtils.isNotBlank(icon) && icon.length() > 256, ErrorCode.PARAMS_ERROR, "图标值过长");
         ThrowUtils.throwIf(StringUtils.isNotBlank(color) && color.length() > 20, ErrorCode.PARAMS_ERROR, "颜色值过长");
         if (sort != null) {
             ThrowUtils.throwIf(sort < 0 || sort > 100, ErrorCode.PARAMS_ERROR, "排序值超出范围");


### PR DESCRIPTION
- 在 PostController 中添加设置帖子加精状态的接口
- 在 PostService 接口中添加设置帖子加精状态的方法
- 在 PostServiceImpl 中实现帖子加精状态的设置逻辑
- 在 TagsServiceImpl 中调整标签图标长度的校验逻辑
- 在数据库中修改标签图标字段长度
- 新增 PostFeaturedRequest 类用于帖子加精请求