### PR TITLE
feat(post): 添加帖子总结功能- 在 Post 模型中添加 summary 字段

### DIFF
--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -136,6 +136,9 @@ create table if not exists post
     index idx_userId (userId),
     index idx_featured (isFeatured)
 ) comment '帖子表' collate = utf8mb4_unicode_ci;
+-- 修改帖子表，新增总结字段
+ALTER TABLE post
+    ADD COLUMN summary TEXT NULL COMMENT '总结';
 
 -- 帖子点赞表（硬删除）
 create table if not exists post_thumb

--- a/src/main/java/com/cong/fishisland/controller/post/PostController.java
+++ b/src/main/java/com/cong/fishisland/controller/post/PostController.java
@@ -20,6 +20,7 @@ import com.cong.fishisland.service.UserService;
 import java.util.List;
 import javax.annotation.Resource;
 
+import com.cong.fishisland.service.event.PostSummaryHandler;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
@@ -44,6 +45,9 @@ public class PostController {
 
     @Resource
     private UserService userService;
+
+    @Resource
+    private PostSummaryHandler postSummaryHandler;
 
     // region 增删改查
 
@@ -71,6 +75,7 @@ public class PostController {
         boolean result = postService.save(post);
         ThrowUtils.throwIf(!result, ErrorCode.OPERATION_ERROR);
         long newPostId = post.getId();
+        postSummaryHandler.generateSummaryAsync(newPostId);
         return ResultUtils.success(newPostId);
     }
 
@@ -125,6 +130,9 @@ public class PostController {
         Post oldPost = postService.getById(id);
         ThrowUtils.throwIf(oldPost == null, ErrorCode.NOT_FOUND_ERROR);
         boolean result = postService.updateById(post);
+        if (result){
+            postSummaryHandler.generateSummaryAsync(id);
+        }
         return ResultUtils.success(result);
     }
 
@@ -240,6 +248,9 @@ public class PostController {
             throw new BusinessException(ErrorCode.NO_AUTH_ERROR);
         }
         boolean result = postService.updateById(post);
+        if (result){
+            postSummaryHandler.generateSummaryAsync(id);
+        }
         return ResultUtils.success(result);
     }
 

--- a/src/main/java/com/cong/fishisland/model/entity/post/Post.java
+++ b/src/main/java/com/cong/fishisland/model/entity/post/Post.java
@@ -84,6 +84,11 @@ public class Post implements Serializable {
      */
     private Integer isFeatured;
 
+    /**
+     * 总结
+     */
+    private String summary;
+
     @TableField(exist = false)
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/com/cong/fishisland/model/vo/post/PostVO.java
+++ b/src/main/java/com/cong/fishisland/model/vo/post/PostVO.java
@@ -94,6 +94,11 @@ public class PostVO implements Serializable {
     private Integer isFeatured;
 
     /**
+     * 摘要
+     */
+    private String summary;
+
+    /**
      * 评论数
      */
     private Integer commentNum;

--- a/src/main/java/com/cong/fishisland/service/event/PostSummaryHandler.java
+++ b/src/main/java/com/cong/fishisland/service/event/PostSummaryHandler.java
@@ -1,0 +1,92 @@
+package com.cong.fishisland.service.event;
+
+import com.cong.fishisland.datasource.ai.AIChatDataSource;
+import com.cong.fishisland.model.entity.post.Post;
+import com.cong.fishisland.model.vo.ai.AiResponse;
+import com.cong.fishisland.model.vo.ai.SiliconFlowRequest;
+import com.cong.fishisland.service.PostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author 许林涛
+ * @date 2025年07月22日 17:11
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostSummaryHandler {
+    @Qualifier("siliconFlowDataSource")
+    private final AIChatDataSource siliconFlowDataSource;
+    @Resource
+    private final PostService postService;
+
+    // 系统预设提示词
+    private static final String SYSTEM_PROMPT =  "你是一名专业的内容摘要生成助手。请基于以下要求处理用户内容：\n"
+            + "1. 使用客观第三人称视角总结内容（避免使用'我'等第一人称代词）\n"
+            + "2. 精准提取核心事实和关键信息\n"
+            + "3. 完全保持原文的客观立场和事实表述\n"
+            + "4. 使用简洁中立的语言表达（不超过100字）\n"
+            + "5. 保留原文的专业术语和关键数据\n"
+            + "6. 输出格式为纯事实陈述文本";
+
+    /**
+     * 异步生成帖子总结
+     *
+     * @param postId 帖子ID
+     */
+    @Async("taskExecutor")
+    public void generateSummaryAsync(Long postId) {
+        if (postId == null){
+            return;
+        }
+        Post post = postService.getById(postId);
+        if (post == null || post.getContent() == null) {
+            log.error("帖子不存在或内容为空: postId={}", postId);
+            return;
+        }
+
+        // 内容长度不足200个字，不生成总结
+        if (post.getContent().length() < 200) {
+            return;
+        }
+
+        try {
+            // 构建AI请求
+            List<SiliconFlowRequest.Message> messages = new ArrayList<>();
+
+            // 系统消息
+            messages.add(new SiliconFlowRequest.Message() {{
+                setRole("system");
+                setContent(SYSTEM_PROMPT);
+            }});
+
+            // 用户消息（帖子内容）
+            messages.add(new SiliconFlowRequest.Message() {{
+                setRole("user");
+                setContent(post.getContent());
+            }});
+
+            // 调用AI生成总结
+            AiResponse aiResponse = siliconFlowDataSource.getAiResponse(
+                    messages,
+                    "Qwen/Qwen2.5-14B-Instruct"
+            );
+            log.info("aiResponse:{}", aiResponse);
+            // 更新帖子总结
+            post.setSummary(aiResponse.getAnswer());
+            postService.updateById(post);
+
+            log.info("帖子总结生成成功: postId={}", postId);
+        } catch (Exception e) {
+            log.error("帖子总结生成失败: postId={}, error={}", postId, e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -19,12 +19,13 @@
         <result property="updateTime" column="updateTime" jdbcType="TIMESTAMP"/>
         <result property="isDelete" column="isDelete" jdbcType="TINYINT"/>
         <result property="isFeatured" column="isFeatured" jdbcType="TINYINT"/>
+        <result property="summary" column="summary" jdbcType="VARCHAR"/>
     </resultMap>
 
     <sql id="Base_Column_List">
         id,title,content,tags,coverImage,
         thumbNum,favourNum,viewNum,userId,
-        createTime,updateTime,isDelete,isFeatured
+        createTime,updateTime,isDelete,isFeatured, summary
     </sql>
 
     <select id="listPostWithDelete" resultType="com.cong.fishisland.model.entity.post.Post">


### PR DESCRIPTION
- 在数据库中添加 summary 列
- 实现 PostSummaryHandler 服务类，用于生成帖子总结
- 在 PostController 中集成总结生成逻辑
- 更新 PostMapper.xml 和 PostVO 以支持 summary 字段